### PR TITLE
Close #37

### DIFF
--- a/trectools/trec_qrel.py
+++ b/trectools/trec_qrel.py
@@ -73,14 +73,26 @@ class TrecQrel:
         dslice[["query", "q0", "docid", "rel"]].to_csv(filename, sep=" ", header=False, index=False)
         print("File %s writen." % (filename))
 
-    def read_qrel(self, filename, qrels_header=["query","q0","docid","rel"]):
+    def read_qrel(self, filename, qrels_header=None):
+        # Replace with default argument for qrel_header
+        if qrels_header is None:
+            qrels_header = ["query", "q0", "docid", "rel"]
+
+        # Set filename
         self.filename = filename
+
+        # Read data from file
         self.qrels_data = pd.read_csv(filename, sep="\s+", names=qrels_header)
 
+        # Enforce string type on docid column (if present)
         if "docid" in self.qrels_data:
             self.qrels_data["docid"] = self.qrels_data["docid"].astype(str)
+        # Enforce string type on q0 column (if present)
         if "q0" in self.qrels_data:
             self.qrels_data["q0"] = self.qrels_data["q0"].astype(str)
+        # Enforce string type on query column (if present)
+        if "query" in self.qrels_data:
+            self.qrels_data["query"] = self.qrels_data["query"].astype(str)
 
         # Removes the files that were not judged:
         self.qrels_data = self.qrels_data[self.qrels_data["rel"] >= 0]

--- a/trectools/trec_run.py
+++ b/trectools/trec_run.py
@@ -63,24 +63,28 @@ class TrecRun(object):
         # Make sure the values are correctly sorted by score
         self.run_data.sort_values(["query", "score", "docid"], inplace=True, ascending=[True, False, True])
 
-    def load_run_from_dataframe(self, df, column_mapping=None):
+    def load_run_from_dataframe`(self, df, column_mapping=None, validate=True):
         # Apply column mapping if specified
         if column_mapping is not None:
             df = df.rename(columns=column_mapping)
 
         # Check if supplied (and optionally renamed) dataframe conforms to required columns
-        required_cols = ["query", "q0", "docid", "rank", "score", "system"]
-        for c in required_cols:
-            if c not in df.keys():
-                print("Error: col %s is not in the dataframe. Aborting." % c)
+        if validate:
+            required_cols = ["query", "q0", "docid", "rank", "score", "system"]
+            for c in required_cols:
+                if c not in df.keys():
+                    print("Error: col %s is not in the dataframe. Aborting." % c)
 
         self.run_data = df.copy()
-        # Enforce string type on docid column
-        self.run_data["docid"] = self.run_data["docid"].astype(str)
-        # Enforce string type on q0 column
-        self.run_data["q0"] = self.run_data["q0"].astype(str)
-        # Enforce string type on query column
-        self.run_data["query"] = self.run_data["query"].astype(str)
+        ## Enforce string type on docid column (if present)
+        if "docid" in self.run_data:
+            self.run_data["docid"] = self.run_data["docid"].astype(str)
+        # Enforce string type on q0 column (if present)
+        if "q0" in self.run_data:
+            self.run_data["q0"] = self.run_data["q0"].astype(str)
+        # Enforce string type on query column (if present)
+        if "query" in self.run_data:
+            self.run_data["query"] = self.run_data["query"].astype(str)
 
     def get_full_filename_path(self):
         """

--- a/trectools/trec_run.py
+++ b/trectools/trec_run.py
@@ -70,10 +70,10 @@ class TrecRun(object):
 
         # Check if supplied (and optionally renamed) dataframe conforms to required columns
         if validate:
-            required_cols = ["query", "q0", "docid", "rank", "score", "system"]
-            for c in required_cols:
-                if c not in df.keys():
-                    print("Error: col %s is not in the dataframe. Aborting." % c)
+            required_cols = {"query", "q0", "docid", "rank", "score", "system"}
+            missing = list(required_cols.difference(set(df.keys())))
+            if len(missing) > 0:
+                raise ValueError(f"Required column(s) {missing} not present in supplied dataframe")
 
         self.run_data = df.copy()
         ## Enforce string type on docid column (if present)

--- a/trectools/trec_run.py
+++ b/trectools/trec_run.py
@@ -83,10 +83,10 @@ class TrecRun(object):
         self.run_data["query"] = self.run_data["query"].astype(str)
 
     def get_full_filename_path(self):
-            """
-                Returns the full path of the run file.
-            """
-            return os.path.abspath(os.path.expanduser(self.filename))
+        """
+            Returns the full path of the run file.
+        """
+        return os.path.abspath(os.path.expanduser(self.filename))
 
     def get_filename(self):
         """

--- a/trectools/trec_run.py
+++ b/trectools/trec_run.py
@@ -63,7 +63,7 @@ class TrecRun(object):
         # Make sure the values are correctly sorted by score
         self.run_data.sort_values(["query", "score", "docid"], inplace=True, ascending=[True, False, True])
 
-    def load_run_from_dataframe`(self, df, column_mapping=None, validate=True):
+    def load_run_from_dataframe(self, df, column_mapping=None, validate=True):
         # Apply column mapping if specified
         if column_mapping is not None:
             df = df.rename(columns=column_mapping)

--- a/trectools/trec_run.py
+++ b/trectools/trec_run.py
@@ -39,29 +39,54 @@ class TrecRun(object):
     def rename_runid(self, name):
         self.run_data["system"] = name
 
-    def read_run(self, filename):
-        self.run_data = pd.read_csv(filename, sep="\s+", names=["query", "q0", "docid", "rank", "score", "system"])
-        # Make sure the values are correctly sorted by score
-        self.run_data.sort_values(["query", "score", "docid"], inplace=True, ascending=[True, False, True])
-        # We assume that docid is a string
-        self.run_data["docid"] = self.run_data["docid"].astype(str)
+    def read_run(self, filename, run_header=None):
+        # Replace with default argument for run_header
+        if run_header is None:
+            run_header = ["query", "q0", "docid", "rank", "score", "system"]
+
+        # Set filename
         self.filename = filename
 
-    def load_run_from_dataframe(self, df):
+        # Read data from file
+        self.run_data = pd.read_csv(filename, sep="\s+", names=run_header)
+
+        # Enforce string type on docid column (if present)
+        if "docid" in self.run_data:
+            self.run_data["docid"] = self.run_data["docid"].astype(str)
+        # Enforce string type on q0 column (if present)
+        if "q0" in self.run_data:
+            self.run_data["q0"] = self.run_data["q0"].astype(str)
+        # Enforce string type on query column (if present)
+        if "query" in self.run_data:
+            self.run_data["query"] = self.run_data["query"].astype(str)
+
+        # Make sure the values are correctly sorted by score
+        self.run_data.sort_values(["query", "score", "docid"], inplace=True, ascending=[True, False, True])
+
+    def load_run_from_dataframe(self, df, column_mapping=None):
+        # Apply column mapping if specified
+        if column_mapping is not None:
+            df = df.rename(columns=column_mapping)
+
+        # Check if supplied (and optionally renamed) dataframe conforms to required columns
         required_cols = ["query", "q0", "docid", "rank", "score", "system"]
         for c in required_cols:
             if c not in df.keys():
                 print("Error: col %s is not in the dataframe. Aborting." % c)
 
         self.run_data = df.copy()
+        # Enforce string type on docid column
+        self.run_data["docid"] = self.run_data["docid"].astype(str)
+        # Enforce string type on q0 column
         self.run_data["q0"] = self.run_data["q0"].astype(str)
-        # self.run_data["docid"] = self.run_data["docid"].astype(str)
+        # Enforce string type on query column
+        self.run_data["query"] = self.run_data["query"].astype(str)
 
     def get_full_filename_path(self):
-        """
-            Returns the full path of the run file.
-        """
-        return os.path.abspath(os.path.expanduser(self.filename))
+            """
+                Returns the full path of the run file.
+            """
+            return os.path.abspath(os.path.expanduser(self.filename))
 
     def get_filename(self):
         """

--- a/unittests/testtreceval.py
+++ b/unittests/testtreceval.py
@@ -14,7 +14,7 @@ class TestTrecEval(unittest.TestCase):
 
         # Contains the first 30 documents for the first 10 topics in input.uic0301
         run3 = TrecRun("./files/input.uic0301_top30")
-        self.common_topics = [303, 307, 310, 314, 320, 322, 325, 330, 336, 341]
+        self.common_topics = ["303", "307", "310", "314", "320", "322", "325", "330", "336", "341"]
         self.teval1 = TrecEval(run1, qrels1)
         self.teval2 = TrecEval(run2, qrels2)
         self.teval3 = TrecEval(run3, qrels2)
@@ -37,7 +37,7 @@ class TestTrecEval(unittest.TestCase):
 
         results = self.teval2.get_reciprocal_rank(depth=1000, trec_eval=True, per_query=True)
         correct_results = [0.0017, 0.1429, 0.3333]
-        values = map(float, results.loc[[378,650,624]].values)
+        values = map(float, results.loc[["378","650","624"]].values)
         for v, c in zip(values, correct_results):
             self.assertAlmostEqual(v, c, places=4)
 
@@ -56,7 +56,7 @@ class TestTrecEval(unittest.TestCase):
 
         results = self.teval2.get_map(depth=1000, trec_eval=True, per_query=True)
         correct_results = [0.4926, 0.2808, 0.2335]
-        values = map(float, results.loc[[622, 609, 320]].values)
+        values = map(float, results.loc[["622", "609", "320"]].values)
         for v, c in zip(values, correct_results):
             self.assertAlmostEqual(v, c, places=4)
 
@@ -75,12 +75,11 @@ class TestTrecEval(unittest.TestCase):
         values1 = self.teval2.get_precision(depth=500, per_query=True, trec_eval=True).loc[self.common_topics].values
         values2 = self.teval3.get_precision(depth=500, per_query=True, trec_eval=True).loc[self.common_topics].values
         for v1, v2 in zip(values1, values2):
-            print(v1,v2)
             self.assertNotAlmostEqual(float(v1), float(v2), places=4)
 
         results = self.teval2.get_precision(depth=30, trec_eval=True, per_query=True)
         correct_results = [0.1333, 0.0333, 0.5333]
-        values = map(float, results.loc[[607, 433, 375]].values)
+        values = map(float, results.loc[["607", "433", "375"]].values)
         for v, c in zip(values, correct_results):
             self.assertAlmostEqual(v, c, places=4)
 

--- a/unittests/testtrecrun.py
+++ b/unittests/testtrecrun.py
@@ -12,7 +12,7 @@ class TestTrecRun(unittest.TestCase):
 
     def test_topics(self):
         topics = self.run.topics()
-        self.assertListEqual(topics, [1,2])
+        self.assertListEqual(topics, ["1","2"])
 
     def test_get_filename(self):
         self.assertEqual(self.run.get_filename(), "r1.run")
@@ -24,11 +24,11 @@ class TestTrecRun(unittest.TestCase):
     def test_topics_intersection_with(self):
         another_run = TrecRun("./files/r2.run")
         intersection = self.run.topics_intersection_with(another_run)
-        self.assertSetEqual(intersection, set([1]))
+        self.assertSetEqual(intersection, {"1"})
 
     def test_get_top_documents(self):
-        topic1_top2 = self.run.get_top_documents(1, n=2)
-        topic2_top2 = self.run.get_top_documents(2, n=2)
+        topic1_top2 = self.run.get_top_documents("1", n=2)
+        topic2_top2 = self.run.get_top_documents("2", n=2)
         self.assertListEqual(topic1_top2, ["doc1_1", "doc1_2"])
         self.assertListEqual(topic2_top2, ["doc2_1", "doc2_3"])
 


### PR DESCRIPTION
This PR introduces changes to the way run- and qrel-files are loaded from disk/memory (#37). The goal is to (1) have forced typing and column name validation with default arguments; and (2) be able to circumvent both automatic checks if needed with custom arguments.

###### Flexible column naming
Tl;dr: `read` methods now all have a `header` argument that allows to specify custom column names. `load` methods have a `mapping` argument to optionally map external columns to the internal representation.

- replace `qrel_header` argument in `TrecQrel.read_qrel` with immutable default
- add `run_header` argument in `TrecRun.read_run` to mirror the `TrecQrel.read_qrel` signature
- add `column_mapping` argument to `TrecRun.load_run_from_dataframe` to optionally map columns to internal representation correctly

###### Forced Typing & Validation
Tl;dr: Columns with default names have forced types. This can be circumvented by using the `header`/`mapping` argument during data loading, as custom column names are not subject to typechecking.

- add forced string typing to `query` column in `TrecQrel`
- add forced string typing to `query`, `q0`, and `docid` column in `TrecRun`
- add `validate` argument to  `TrecRun.load_run_from_dataframe` to trigger column name validation (default True)
- column validation in `TrecRun.load_run_from_dataframe` now raises a ValueError instead of printing, and produces the full list of missing columns

###### Unittests
Tl;dr: unittest adaptation
- adapt `testtrecrun.py` unittests to forced string type
- adapt `testtreceval.py` unittests to forced string type
- remove print statement from `testtreceval.test_get_precision`