### PR TITLE
Fix typo

### DIFF
--- a/trectools/trec_eval.py
+++ b/trectools/trec_eval.py
@@ -258,8 +258,8 @@ class TrecEval:
 
             Returns
             --------
-            if per_query == True: returns a pandas dataframe with two cols (query, MAP@X)
-            else: returns a float value representing the MAP@deph.
+            if per_query == True: returns a pandas dataframe with two cols (query, recip_rank@X)
+            else: returns a float value representing the recip_rank@depth.
 
         """
 


### PR DESCRIPTION
This change replaces "MAP@depth" with recip_rank@depth in the documentation of the method get_reciprocal_rank.