### PR TITLE
Add labels parameter to sklearn confusion matrix function

### DIFF
--- a/trectools/trec_qrel.py
+++ b/trectools/trec_qrel.py
@@ -195,7 +195,7 @@ class TrecQrel:
                 print("ERROR in filtering topics")
                 return None
             print("Resulting topics being used: ", r["query"].unique())
-        return metrics.confusion_matrix(r["rel_x"], r["rel_y"], labels)
+        return metrics.confusion_matrix(r["rel_x"], r["rel_y"], labels=labels)
 
     def explore_agreement(self, another_qrel, topic):
         """


### PR DESCRIPTION
It looks like sklearn was updated and now the labels argument needs to be passed as a keyword argument rather than a positional argument.